### PR TITLE
Use err() instead of print "" for py3 compatibility

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -179,7 +179,7 @@ def get_repo():
         remote, user, repo = m.groups()
         repo = gh.repository(user, repo)
         if not repo:
-            print "Repository %s/%s no longer exists on github" % m.groups()[1:]
+            err("Repository %s/%s no longer exists on github" % m.groups()[1:])
             continue
         repo.remote = remote
         if remote == 'origin':


### PR DESCRIPTION
Commit 2988182a9ef43885ca161a384b919f4da4dc9347 broke python 3 compatibility by using a print statement. This uses the more appropriate err() function instead.
