### PR TITLE
Fix encoding issue

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -272,7 +272,7 @@ def repos(opts):
         name = repo.name
         if opts['<user>'][0] != repo.owner.login:
             name = '%s/%s' % (repo.owner.login, name)
-        print(wrap(fmt % (name, repo.description), *color))
+        print(wrap((fmt % (name, repo.description)).encode("Utf-8"), *color))
 
 @command
 def clone(opts):


### PR DESCRIPTION
Hello,

To reproduce: git hub repos | grep stuff

Python has this wonderful ability to not fail on encoding problem when you only output on the shell, but once you do a "|" or ">" or ">>" it will miserably fail. I haven't checked the other commands.

Kind regards,  
