### PR TITLE
python3: raw_input -> input

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -38,6 +38,8 @@ PY3 = sys.version_info[0] > 2
 if PY3:
     # On python 3, shell decodes into utf-8 as above
     try_decode = lambda x: x
+    # On python 3, raw_input has become input
+    raw_input = input
 else:
     # Try decoding as utf-8 only
     try_decode = lambda x: x.decode('utf-8')


### PR DESCRIPTION
This is a simple dirty fix that aliases `raw_input` as `input` to make sure it works on python3. I've tested it and it works on my python3.3.
