### PR TITLE
Fix Python3 syntax error in docs/ansicolor.py

### DIFF
--- a/docs/ansicolor.py
+++ b/docs/ansicolor.py
@@ -41,7 +41,7 @@ def process_escape(match):
             }[color]
             return '<span style="color: #%s">' % color
         return '<span style="%s">' % '; '.join([", ".join([': '.join(x) for x in attr.items()]) for attr in attrs])
-    print match.groups()
+    print(match.groups())
 
 def mangle_html(app, exception):
     if app.builder.name != 'html' or exception:


### PR DESCRIPTION
Use Python 3 compatible syntax for a `print` statement.