### PR TITLE
Use XDG config directory

### DIFF
--- a/lib/gitspindle/__init__.py
+++ b/lib/gitspindle/__init__.py
@@ -51,6 +51,12 @@ class GitSpindle(Singleton):
             self.git_dir = None
         self.in_repo = bool(self.git_dir)
         self.config_file = os.path.join(os.path.expanduser('~'), '.gitspindle')
+        if not os.path.exists(self.config_file):
+            config_dir = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+            config_dir = os.path.join(config_dir, 'git')
+            if not os.path.exists(config_dir):
+                os.makedirs(config_dir)
+            self.config_file = os.path.join(config_dir, 'spindle')
         self.commands = {}
         self.usage = """%s - %s integration for git
 A full manual can be found on http://seveas.github.com/git-spindle/


### PR DESCRIPTION
To avoid contributing to ~/.dotfile clutter, `$XDG_CONFIG_HOME/git/spindle` should be the primary location (with the old path as fallback of course).

Git itself did the same in v1.7.12: gitster/git@21cf32279120799a766d22416be7d82d9ecfbd04 (core), gitster/git@0e8593dc5b812df00400347e88f5707225fe831e (core), gitster/git@dc79687e0b70805894d1b4432cef7164ae86e033 (gitignore), gitster/git@8f86339858c1325645f8eaf6950dfd9d74cc9897 (gitk)).