### PR TITLE
Fixing issue with non-existent variable.

### DIFF
--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -25,7 +25,7 @@ class GitHub(GitSpindle):
     def login(self):
         host = self.config('host')
         if host and host not in ('https://api.github.com', 'api.github.com'):
-            if not hosts.startswith(('http://', 'https://')):
+            if not host.startswith(('http://', 'https://')):
                 host = 'https://' + host
             self.gh = github3.GitHubEnterprise(url=host)
         else:


### PR DESCRIPTION
Noticed the use of the wrong variable name (plural versus singular), which causes the entire tool to not function.

Error before fixing when running any 'git hub' commands:
NameError: global name 'hosts' is not defined