### PR TITLE
Make git lab fork work for projects you are a member of

### DIFF
--- a/lib/gitspindle/gitlab.py
+++ b/lib/gitspindle/gitlab.py
@@ -271,7 +271,8 @@ class GitLab(GitSpindle):
         if repo.owner.username == self.my_login:
             err("You cannot fork your own repos")
 
-        if repo.name in [x.name for x in self.gl.Project()]:
+        my_repo = self.find_repo(self.my_login, repo.name)
+        if my_repo:
             err("Repository already exists")
 
         opts['<repo>'] = repo.fork().name


### PR DESCRIPTION
The git lab fork command will fail to fork a project which you are a member of
as it finds that you have a project with the same name, even though it belongs
to a different user.

Alter the method used to check that do not already have a fork of the project.