### PR TITLE
Install bash completion script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='git-spindle',
     scripts=['bin/git-hub', 'bin/git-lab', 'bin/git-bb', 'bin/git-bucket'],
     packages=['gitspindle'],
     package_dir={'': 'lib'},
+    data_files=[('share/bash-completion/completions/', ['completion/git-spindle.completion.bash'])],
     classifiers=[
         "Intended Audience :: Developers",
         "Topic :: Software Development",


### PR DESCRIPTION
This will install the completion script into
`~/.local/share/bash-completion/completions/` when using `pip install --user` and
in `/usr/share/bash-completion/completions/` otherwise.