### PR TITLE
Porting the github backend to github3.py 1.0.0

### DIFF
--- a/docs/github.rst
+++ b/docs/github.rst
@@ -266,7 +266,7 @@ Revoke access to this repository.
 List all protected branches. Protected branches cannot be force-pushed or
 deleted, and can potentially have required status checks.
 
-.. describe:: git hub protect [--enforcement-level=<level>] [--contexts=<contexts>] <branch>
+.. describe:: git hub protect [--enforcement=<level>] [--status_checks=<contexts>] <branch>
 
 Protect a branch against force-pushes and deletion. Optionally require status
 checks to succeed by specifying their context (e.g.

--- a/lib/gitspindle/__init__.py
+++ b/lib/gitspindle/__init__.py
@@ -539,16 +539,16 @@ Options:
 
         if self.api.__name__ == 'github3':
             if opts['--keys']:
-                for key in self.gh.iter_keys():
+                for key in self.gh.keys():
                     key.delete()
             if opts['--repos']:
                 if namespace != self.my_login:
-                    for repo in self.gh.organization(namespace).iter_repos():
+                    for repo in self.gh.organization(namespace).repositories():
                         print(repo)
                         if not repo.delete():
                             raise RuntimeError("Deleting repository failed")
                 else:
-                    for repo in self.gh.iter_repos():
+                    for repo in self.gh.repositories():
                         if repo.owner.login == namespace:
                             print(repo)
                             if not repo.delete():
@@ -560,14 +560,14 @@ Options:
                 tries = 120/5
                 clean = False
                 while tries and not clean:
-                    clean = namespace not in [x.owner.login for x in self.gh.iter_repos()]
+                    clean = namespace not in [x.owner.login for x in self.gh.repositories()]
                     if not clean:
                         tries -= 1
                         time.sleep(5)
                 if not clean:
                     raise RuntimeError("Deleting repositories failed, try again in some minutes or increase the wait timeout in test_cleanup")
             if opts['--gists']:
-                for gist in self.gh.iter_gists():
+                for gist in self.gh.gists():
                     gist.delete()
 
         elif self.api.__name__ == 'gitspindle.bbapi':

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -60,7 +60,7 @@ class GitHub(GitSpindle):
                 for error in response.json()['errors']:
                     if error['resource'] == 'OauthAccess' and error['code'] == 'already_exists':
                         if os.getenv('DEBUG') or self.question('An OAuth token for this host already exists. Shall I delete it?', default=False):
-                            for auth in self.gh.iter_authorizations():
+                            for auth in self.gh.authorizations():
                                 if auth.app['name'] in (name, '%s (API)' % name):
                                     auth.delete()
                             auth = self.gh.authorize(user, password, scopes, name, "http://seveas.github.com/git-spindle")
@@ -182,7 +182,7 @@ class GitHub(GitSpindle):
         """<name> [<setting>...]
            Add a repository hook"""
         repo = self.repository(opts)
-        for hook in repo.iter_hooks():
+        for hook in repo.hooks():
             if hook.name == opts['<name>']:
                 raise ValueError("Hook %s already exists" % opts['<name>'])
         settings = dict([x.split('=', 1) for x in opts['<setting>']])
@@ -237,7 +237,7 @@ class GitHub(GitSpindle):
     def add_remote(self, opts):
         """[--ssh|--http|--git] <user> [<name>]
            Add user's fork as a named remote. The name defaults to the user's loginname"""
-        for fork in self.repository(opts).iter_forks():
+        for fork in self.repository(opts).forks():
             if fork.owner.login in opts['<user>']:
                 url = self.clone_url(fork, opts)
                 name = opts['<name>'] or fork.owner.login
@@ -249,7 +249,7 @@ class GitHub(GitSpindle):
            Adds keys to your public keys"""
         if not opts['<key>']:
             opts['<key>'] = glob.glob(os.path.join(os.path.expanduser('~'), '.ssh', 'id_*.pub'))
-        existing = [x.key for x in self.gh.iter_keys()]
+        existing = [x.key for x in self.gh.keys()]
         for arg in opts['<key>']:
             with open(arg) as fd:
                 algo, key, title = fd.read().strip().split(None, 2)
@@ -475,7 +475,7 @@ class GitHub(GitSpindle):
 
         # Do we have unverified emails
         if repo.owner.login == self.me.login:
-            for mail in self.gh.iter_emails():
+            for mail in self.gh.emails():
                 if not mail['verified']:
                     error("Unverified %s email address: %s" % (mail['primary'] and 'primary' or 'secondary', mail['email']))
 
@@ -553,7 +553,7 @@ class GitHub(GitSpindle):
         """[<repo>]
            List collaborators of a repository"""
         repo = self.repository(opts)
-        users = list(repo.iter_collaborators())
+        users = list(repo.collaborators())
         users.sort(key = lambda user: user.login)
         for user in users:
             print(user.login)
@@ -571,7 +571,7 @@ class GitHub(GitSpindle):
             dest = self.gh
             ns = self.my_login
 
-        if name in [x.name for x in dest.iter_repos() if x.owner.login == ns]:
+        if name in [x.name for x in dest.repositories() if x.owner.login == ns]:
             err("Repository already exists")
         repo = dest.create_repo(name=name, description=opts['--description'] or "", private=opts['--private'])
 
@@ -605,7 +605,7 @@ class GitHub(GitSpindle):
                 for error in exc.response.json()['errors']:
                     if error['resource'] == 'OauthAccess' and error['code'] == 'already_exists':
                         if os.getenv('DEBUG'):
-                            for auth in gh.iter_authorizations():
+                            for auth in gh.authorizations():
                                 if auth.app['name'] in (name, '%s (API)' % name):
                                     auth.delete()
                             auth = gh.authorize(self.my_login, password, scopes, name, "http://git-scm.com")
@@ -628,7 +628,7 @@ class GitHub(GitSpindle):
         """[<repo>]
            Lists all keys for a repo"""
         repo = self.repository(opts)
-        for key in repo.iter_keys():
+        for key in repo.keys():
             ro = key._json_data['read_only'] and 'ro' or 'rw'
             print("%s %s (id: %s, %s)" % (key.key, key.title or '', key.id, ro))
 
@@ -636,7 +636,7 @@ class GitHub(GitSpindle):
     def edit_hook(self, opts):
         """<name> [<setting>...]
            Edit a hook"""
-        for hook in self.repository(opts).iter_hooks():
+        for hook in self.repository(opts).hooks():
             if hook.name == opts['<name>']:
                 break
         else:
@@ -655,7 +655,7 @@ class GitHub(GitSpindle):
     def fetch(self, opts):
         """[--ssh|--http|--git] <user> [<refspec>]
            Fetch refs from a user's fork"""
-        for fork in self.repository(opts).iter_forks():
+        for fork in self.repository(opts).forks():
             if fork.owner.login in opts['<user>']:
                 url = self.clone_url(fork, opts)
                 refspec = opts['<refspec>'] or 'refs/heads/*'
@@ -676,11 +676,11 @@ class GitHub(GitSpindle):
             err("You cannot fork your own repos")
 
         if isinstance(repo, github3.gists.Gist):
-            for fork in repo.iter_forks():
+            for fork in repo.forks():
                 if fork.owner.login == self.my_login:
                     err("You already forked this gist as %s" % fork.html_url)
         else:
-            if repo.name in [x.name for x in self.gh.iter_repos() if x.owner.login == self.my_login]:
+            if repo.name in [x.name for x in self.gh.repos() if x.owner.login == self.my_login]:
                 err("Repository already exists")
 
         my_clone = repo.create_fork()
@@ -697,7 +697,7 @@ class GitHub(GitSpindle):
            List all forks of this repository"""
         repo = self.repository(opts)
         print("[%s] %s" % (wrap(repo.owner.login, attr.bright), repo.html_url))
-        for fork in repo.iter_forks():
+        for fork in repo.forks():
             print("[%s] %s" % (fork.owner.login, fork.html_url))
 
     @command
@@ -722,13 +722,13 @@ class GitHub(GitSpindle):
         """[<user>]
            Show all gists for a user"""
         user = (opts['<user>'] or [self.gh.me().login])[0]
-        for gist in self.gh.iter_gists(user):
+        for gist in self.gh.gists_by(user):
             print("%s - %s" % (gist.html_url, gist.description))
 
     @command
     def hooks(self, opts):
         """\nShow hooks that have been enabled"""
-        for hook in self.repository(opts).iter_hooks():
+        for hook in self.repository(opts).hooks():
             print(wrap("%s (%s)" % (hook.name, ', '.join(hook.events)), attr.bright))
             for key, val in sorted(hook.config.items()):
                 if val in (None, ''):
@@ -806,14 +806,14 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
             opts['<filter>'].insert(0, opts['<repo>'])
             opts['<repo>'] = None
         if (not opts['<repo>'] and not self.in_repo) or opts['<repo>'] == '--':
-            repos = list(self.gh.iter_repos(type='all'))
+            repos = list(self.gh.repositories(type='all'))
         else:
             repos = [self.repository(opts)]
         for repo in repos:
             repo = (opts['--parent'] and self.parent_repo(repo)) or repo
             filters = dict([x.split('=', 1) for x in opts['<filter>']])
             try:
-                issues = list(repo.iter_issues(**filters))
+                issues = list(repo.issues(**filters))
             except github3.GitHubError:
                 _, err, _ = sys.exc_info()
                 if err.code == 410:
@@ -858,11 +858,11 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
                     err("User %s does not exist" % opts['<what>'])
 
         if not opts['--type']:
-            events = [x for x in what.iter_events(number=count)]
+            events = [x for x in what.events(number=count)]
         else:
             events = []
             etype = opts['--type'].lower() + 'event'
-            for event in what.iter_events(number=-1):
+            for event in what.events(number=-1):
                 if event.type.lower() == etype:
                     events.append(event)
                     if len(events) == count:
@@ -988,12 +988,12 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
            Mirror a repository, or all repositories for a user"""
         if opts['<repo>'] and opts['<repo>'].endswith('/*'):
             user = opts['<repo>'].rsplit('/', 2)[-2]
-            for repo in self.gh.iter_repos(type='all') if user == self.my_login else self.gh.iter_user_repos(user, type='all'):
+            for repo in self.gh.repositories(type='all') if user == self.my_login else self.gh.repositories_by(user, type='all'):
                 if repo.owner.login != self.my_login:
                     continue
                 opts['<repo>'] = '%s/%s' % (user, repo)
                 self.mirror(opts)
-            for repo in self.gh.iter_gists(user):
+            for repo in self.gh.gists_by(user):
                 opts['<repo>'] = 'gist/%s' % repo.name
                 self.mirror(opts)
             return
@@ -1051,17 +1051,17 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
 
                 sys.stderr.write("Looking at user %s\n" % login)
                 # Followers
-                for other in person.user.iter_followers():
+                for other in person.user.followers():
                     if other.login not in people:
                         people[other.login] = P(other)
                     people[other.login].rel_to[login].append('follows')
-                for other in person.user.iter_following():
+                for other in person.user.following():
                     if other.login not in people:
                         people[other.login] = P(other)
                     person.rel_to[other.login].append('follows')
 
                 # Forks
-                for repo in self.gh.iter_user_repos(login, type='owner'):
+                for repo in self.gh.repositories_by(login, type='owner'):
                     sys.stderr.write("Looking at repo %s\n" % repo.name)
                     if repo.fork:
                         if repo.owner.login not in people:
@@ -1069,7 +1069,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
                         parent = self.parent_repo(repo)
                         person.rel_to[parent.owner.login].append('forked %s' % parent.name)
                     else:
-                        for fork in repo.iter_forks():
+                        for fork in repo.forks():
                             if fork.owner.login == login:
                                 continue
                             if fork.owner.login not in people:
@@ -1100,7 +1100,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
     def protected(self, opts):
         """\nList active branch protections"""
         repo = self.repository(opts)
-        for branch in repo.iter_branches(protected=True):
+        for branch in repo.branches(protected=True):
             data = branch._json_data['protection']
             msg = branch.name
             if data['required_status_checks']['contexts'] and data['required_status_checks']['enforcement_level'] != 'off':
@@ -1113,9 +1113,9 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
            Lists all keys for a user"""
         user = opts['<user>'] and opts['<user>'][0] or self.my_login
         if self.my_login == user:
-            keys = self.gh.iter_keys()
+            keys = self.gh.keys()
         else:
-            keys = self.gh.user(user).iter_keys()
+            keys = self.gh.user(user).keys()
         for key in keys:
             print("%s %s" % (key.key, key.title or ''))
 
@@ -1276,7 +1276,7 @@ will be ignored""" % (name, tag)
         """[<repo>]
            List all releases"""
         repo = self.repository(opts)
-        for release in repo.iter_releases():
+        for release in repo.releases():
             status = []
             if release.draft:
                 status.append('draft')
@@ -1305,7 +1305,7 @@ will be ignored""" % (name, tag)
     def remove_hook(self, opts):
         """<name>
            Remove a hook"""
-        for hook in self.repository(opts).iter_hooks():
+        for hook in self.repository(opts).hooks():
             if hook.name == opts['<name>']:
                 hook.delete()
 
@@ -1354,9 +1354,9 @@ will be ignored""" % (name, tag)
         """[--no-forks] [<user>]
            List all repos of a user, by default yours"""
         if opts['<user>']:
-            repos = list(self.gh.iter_user_repos(opts['<user>'][0]))
+            repos = list(self.gh.repositories_by(opts['<user>'][0]))
         else:
-            repos = list(self.gh.iter_repos(type='all'))
+            repos = list(self.gh.repositories(type='all'))
             opts['<user>'] = [self.my_login]
         if not repos:
             return
@@ -1441,7 +1441,7 @@ will be ignored""" % (name, tag)
         else:
             # If issues are enabled, fetch pull requests
             try:
-                list(repo.iter_issues(number=1))
+                list(repo.issues(number=1))
             except github3.GitHubError:
                 pass
             else:
@@ -1503,7 +1503,7 @@ will be ignored""" % (name, tag)
                 continue
             emails = {}
             if user.login == self.my_login:
-                for email in self.gh.iter_emails():
+                for email in self.gh.emails():
                     emails[email['email']] = email
             print(wrap(user.name or user.login, attr.bright, attr.underline))
             print('Profile   %s' % user.html_url)
@@ -1528,9 +1528,9 @@ will be ignored""" % (name, tag)
             print('Repos     %d public, %d private' % (user.public_repos, user.total_private_repos))
             print('Gists     %d public, %d private' % (user.public_gists, user.total_private_gists))
             if user.login == self.my_login:
-                keys = self.gh.iter_keys()
+                keys = self.gh.keys()
             else:
-                keys = user.iter_keys()
+                keys = user.keys()
             for pkey in keys:
                 algo, key = pkey.key.split()[:2]
                 algo = algo[4:].upper()
@@ -1539,14 +1539,14 @@ will be ignored""" % (name, tag)
                 else:
                     print("%s key%s...%s" % (algo, ' ' * (6 - len(algo)), key[-10:]))
             if user.login == self.my_login:
-                orgs = self.gh.iter_orgs()
+                orgs = self.gh.organizations()
             else:
-                orgs = list(user.iter_orgs())
+                orgs = list(user.organizations())
             if orgs:
                 print("Member of %s" % ', '.join([x.login for x in orgs]))
             if user.type == 'Organization':
                 print('Members:')
-                for member in self.gh.organization(user.login).iter_members():
+                for member in self.gh.organization(user.login).members():
                     print(" - %s" % member.login)
 
 def prompt_for_2fa(user, cache={}):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -84,7 +84,8 @@ class GitHub(GitSpindle):
             err("No user or token specified")
         self.gh.login(username=user, token=token)
         try:
-            self.me = self.gh.user()
+
+            self.me = self.gh.me()
             self.my_login = self.me.login
         except github3.GitHubError:
             # Token obsolete
@@ -720,7 +721,7 @@ class GitHub(GitSpindle):
     def gists(self, opts):
         """[<user>]
            Show all gists for a user"""
-        user = (opts['<user>'] or [self.gh.user().login])[0]
+        user = (opts['<user>'] or [self.gh.me().login])[0]
         for gist in self.gh.iter_gists(user):
             print("%s - %s" % (gist.html_url, gist.description))
 

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -673,7 +673,7 @@ class GitHub(GitSpindle):
                 if fork.owner.login == self.my_login:
                     err("You already forked this gist as %s" % fork.html_url)
         else:
-            if repo.name in [x.name for x in self.gh.repos() if x.owner.login == self.my_login]:
+            if repo.name in [x.name for x in self.gh.repositories() if x.owner.login == self.my_login]:
                 err("Repository already exists")
 
         my_clone = repo.create_fork()

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1507,9 +1507,11 @@ will be ignored""" % (name, tag)
             print('Profile   %s' % user.html_url)
             if user.email:
                 unverified = ''
-                if not emails.get(user.email, {}).verified:
-                    unverified = ' ' + wrap('(not verified)', fgcolor.red, attr.bright)
-                print('Email     %s%s' % (user.email, unverified))
+                user_email = emails.get(user.email)
+                if user_email is not None:
+                    if not user_email.verified:
+                        unverified = ' ' + wrap('(not verified)', fgcolor.red, attr.bright)
+                    print('Email     %s%s' % (user.email, unverified))
                 for email in emails:
                     if email == user.email:
                         continue

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -149,7 +149,7 @@ class GitHub(GitSpindle):
                     if file.startswith(template + '.'):
                         contents = files[file]
         if contents:
-            contents = contents.name, self.gh._session.get(contents._json_data['download_url'], stream=True).text
+            contents = contents.name, self.gh._session.get(contents.download_url, stream=True).text
         return contents
 
     # Commands
@@ -623,8 +623,7 @@ class GitHub(GitSpindle):
            Lists all keys for a repo"""
         repo = self.repository(opts)
         for key in repo.keys():
-            ro = key._json_data['read_only'] and 'ro' or 'rw'
-            print("%s %s (id: %s, %s)" % (key.key, key.title or '', key.id, ro))
+            print("%s %s (id: %s)" % (key.key, key.title or '', key.id))
 
     @command
     def edit_hook(self, opts):
@@ -905,7 +904,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
             elif event.type == 'IssueCommentEvent':
                 print("%s commented on issue #%s%s" % (ts, event.payload['issue'].number, repo_))
                 if verbose:
-                    print("%s %s %s" % (tss, event.payload['issue'].title, event.payload['comment']._json_data['html_url']))
+                    print("%s %s %s" % (tss, event.payload['issue'].title, event.payload['comment'].html_url))
             elif event.type == 'IssuesEvent':
                 print("%s %s issue #%s%s" % (ts, event.payload['action'], event.payload['issue'].number, repo_))
                 if verbose:
@@ -1093,7 +1092,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
         """\nList active branch protections"""
         repo = self.repository(opts)
         for branch in repo.branches(protected=True):
-            data = branch._json_data['protection']
+            data = branch.protection
             msg = branch.name
             if data['required_status_checks']['contexts'] and data['required_status_checks']['enforcement_level'] != 'off':
                 msg += ' (%s must pass for %s)' % (','.join(data['required_status_checks']['contexts']), data['required_status_checks']['enforcement_level'])
@@ -1353,10 +1352,8 @@ will be ignored""" % (name, tag)
         if not repos:
             return
         maxlen = max([len(x.name) for x in repos])
-        # XXX github3.py PR 193
-        # maxstar = len(str(max([x.stargazers for x in repos])))
-        maxstar = len(str(max([x._json_data['stargazers_count'] for x in repos])))
-        maxfork = len(str(max([x.forks for x in repos])))
+        maxstar = len(str(max([x.stargazers_count for x in repos])))
+        maxfork = len(str(max([x.forks_count for x in repos])))
         maxwatch = len(str(max([x.watchers for x in repos])))
         # XXX github support request filed: watchers is actually stars
         #fmt = u"%%-%ds \u2605 %%-%ds \u25c9 %%-%ds \u2919 %%-%ds %%s" % (maxlen, maxstar, maxwatch, maxfork)
@@ -1372,7 +1369,7 @@ will be ignored""" % (name, tag)
             name = repo.name
             if opts['<user>'][0] != repo.owner.login:
                 name = '%s/%s' % (repo.owner.login, name)
-            msg = wrap(fmt % (name, repo._json_data['stargazers_count'], repo.forks, repo.description), *color)
+            msg = wrap(fmt % (name, repo.stargazers_count, repo.forks_count, repo.description), *color)
             if not PY3:
                 msg = msg.encode('utf-8')
             print(msg)

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -137,7 +137,10 @@ class GitHub(GitSpindle):
         template = template.lower()
         contents = None
         for dir in ('/', '/.github/'):
-            files = repo.directory_contents(dir)
+            try:
+                files = repo.directory_contents(dir)
+            except github3.exceptions.NotFoundError:
+                files = None
             if not files or not hasattr(files, 'items'):
                 continue
             files = dict([(k.lower(), v) for k, v in files])
@@ -1141,7 +1144,10 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
         # Try to get the local commit
         commit = self.gitm('show-ref', 'refs/heads/%s' % src).stdout.split()[0]
         # Do they exist on github?
-        srcb = repo.branch(src)
+        try:
+            srcb = repo.branch(src)
+        except github3.exceptions.NotFoundError:
+            srcb = None
         if not srcb:
             if self.question("Branch %s does not exist in your GitHub repo, shall I push?" % src):
                 self.gitm('push', '-u', repo.remote, src, redirect=False)

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -768,7 +768,7 @@ class GitHub(GitSpindle):
                 pr = issue.pull_request()
                 print(wrap(issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), attr.bright, attr.underline))
                 print(issue.body.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding))
-                print(pr and pr.html_url or issue.html_url)
+                print(pr.html_url if pr is not None else issue.html_url)
             else:
                 print('No issue with id %s found in repository %s' % (issue_no, repo.full_name))
         if not opts['<issue>']:
@@ -824,7 +824,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
             print(wrap("Issues for %s/%s" % (repo.owner.login, repo.name), attr.bright))
             for issue in issues:
                 pr = issue.pull_request()
-                url = pr and pr.html_url or issue.html_url
+                url = pr.html_url if pr is not None else issue.html_url
                 print("[%d] %s %s" % (issue.number, issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), url))
 
     @command

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1523,8 +1523,8 @@ will be ignored""" % (name, tag)
                 print('Location  %s' % user.location)
             if user.company:
                 print('Company   %s' % user.company)
-            print('Repos     %d public, %d private' % (user.public_repos_count, user.total_private_repos))
-            print('Gists     %d public, %d private' % (user.public_gists, user.total_private_gists))
+            print('Repos     %d' % user.public_repos_count)
+            print('Gists     %d' % user.public_gists_count)
             if user.login == self.my_login:
                 keys = self.gh.keys()
             else:

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1114,10 +1114,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
         else:
             keys = self.gh.user(user).keys()
         for key in keys:
-            if getattr(key, 'title', None):
-                print("%s %s" % (key.key, key.title or ''))
-            else:
-                print("%s" % key.key)
+            print("%s %s" % (key.key, getattr(key, 'title', '')))
 
 
     @command

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -378,7 +378,9 @@ class GitHub(GitSpindle):
                 err("No such file: %s" % arg)
             if content.type != 'file':
                 err("Not a regular file: %s" % arg)
-            os.write(sys.stdout.fileno(), content.decoded)
+            resp = self.gh._session.get(content.download_url, stream=True)
+            for chunk in resp.iter_content(4096):
+                os.write(sys.stdout.fileno(), chunk)
 
     @command
     def check_pages(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1114,7 +1114,7 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
         else:
             keys = self.gh.user(user).keys()
         for key in keys:
-            if hasattr(key, 'title') and key.title:
+            if getattr(key, 'title', None):
                 print("%s %s" % (key.key, key.title or ''))
             else:
                 print("%s" % key.key)
@@ -1538,7 +1538,7 @@ will be ignored""" % (name, tag)
             for pkey in keys:
                 algo, key = pkey.key.split()[:2]
                 algo = algo[4:].upper()
-                if hasattr(pkey, 'title') and pkey.title:
+                if getattr(pkey, 'title', None):
                     print("%s key%s...%s (%s)" % (algo, ' ' * (6 - len(algo)), key[-10:], pkey.title))
                 else:
                     print("%s key%s...%s" % (algo, ' ' * (6 - len(algo)), key[-10:]))

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1516,7 +1516,7 @@ will be ignored""" % (name, tag)
                 print('Location  %s' % user.location)
             if user.company:
                 print('Company   %s' % user.company)
-            print('Repos     %d public, %d private' % (user.public_repos, user.total_private_repos))
+            print('Repos     %d public, %d private' % (user.public_repos_count, user.total_private_repos))
             print('Gists     %d public, %d private' % (user.public_gists, user.total_private_gists))
             if user.login == self.my_login:
                 keys = self.gh.keys()

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -84,7 +84,6 @@ class GitHub(GitSpindle):
             err("No user or token specified")
         self.gh.login(username=user, token=token)
         try:
-
             self.me = self.gh.me()
             self.my_login = self.me.login
         except github3.GitHubError:

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1496,12 +1496,12 @@ will be ignored""" % (name, tag)
             emails = {}
             if user.login == self.my_login:
                 for email in self.gh.emails():
-                    emails[email['email']] = email
+                    emails[str(email)] = email
             print(wrap(user.name or user.login, attr.bright, attr.underline))
             print('Profile   %s' % user.html_url)
             if user.email:
                 unverified = ''
-                if not emails.get(user.email, {}).get('verified', True):
+                if not emails.get(user.email, {}).verified:
                     unverified = ' ' + wrap('(not verified)', fgcolor.red, attr.bright)
                 print('Email     %s%s' % (user.email, unverified))
                 for email in emails:

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -126,7 +126,7 @@ class GitHub(GitSpindle):
 
     def api_root(self):
         if hasattr(self, 'gh'):
-            return self.gh._session.base_url
+            return self.gh.session.base_url
         host = self.config('host')
         if not host:
             return 'https://api.github.com'
@@ -151,7 +151,7 @@ class GitHub(GitSpindle):
                     if file.startswith(template + '.'):
                         contents = files[file]
         if contents:
-            contents = contents.name, self.gh._session.get(contents.download_url, stream=True).text
+            contents = contents.name, self.gh.session.get(contents.download_url, stream=True).text
         return contents
 
     # Commands
@@ -378,7 +378,7 @@ class GitHub(GitSpindle):
                 err("No such file: %s" % arg)
             if content.type != 'file':
                 err("Not a regular file: %s" % arg)
-            resp = self.gh._session.get(content.download_url, stream=True)
+            resp = self.gh.session.get(content.download_url, stream=True)
             for chunk in resp.iter_content(4096):
                 os.write(sys.stdout.fileno(), chunk)
 

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -567,7 +567,7 @@ class GitHub(GitSpindle):
 
         if name in [x.name for x in dest.repositories() if x.owner.login == ns]:
             err("Repository already exists")
-        repo = dest.create_repo(name=name, description=opts['--description'] or "", private=opts['--private'])
+        repo = dest.create_repository(name=name, description=opts['--description'] or "", private=opts['--private'])
 
         if 'origin' in self.remotes():
             print("Remote 'origin' already exists, adding the GitHub repository as 'github'")
@@ -1291,7 +1291,7 @@ will be ignored""" % (name, tag)
            Remove deploy key by id"""
         repo = self.repository(opts)
         for key in opts['<key>']:
-            repo.delete_key(key)
+            repo.key(key).delete()
 
     @command
     def remove_hook(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -625,7 +625,8 @@ class GitHub(GitSpindle):
            Lists all keys for a repo"""
         repo = self.repository(opts)
         for key in repo.keys():
-            print("%s %s (id: %s)" % (key.key, key.title or '', key.id))
+            ro = 'ro' if key.read_only else 'rw'
+            print("%s %s (id: %s, %s)" % (key.key, key.title or '', key.id, ro))
 
     @command
     def edit_hook(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -762,9 +762,10 @@ class GitHub(GitSpindle):
         for issue_no in opts['<issue>']:
             issue = repo.issue(issue_no)
             if issue:
+                pr = issue.pull_request()
                 print(wrap(issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), attr.bright, attr.underline))
                 print(issue.body.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding))
-                print(issue.pull_request and issue.pull_request['html_url'] or issue.html_url)
+                print(pr and pr.html_url or issue.html_url)
             else:
                 print('No issue with id %s found in repository %s' % (issue_no, repo.full_name))
         if not opts['<issue>']:
@@ -819,7 +820,8 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
                 continue
             print(wrap("Issues for %s/%s" % (repo.owner.login, repo.name), attr.bright))
             for issue in issues:
-                url = issue.pull_request and issue.pull_request['html_url'] or issue.html_url
+                pr = issue.pull_request()
+                url = pr and pr.html_url or issue.html_url
                 print("[%d] %s %s" % (issue.number, issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), url))
 
     @command

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1114,7 +1114,11 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
         else:
             keys = self.gh.user(user).keys()
         for key in keys:
-            print("%s %s" % (key.key, key.title or ''))
+            if hasattr(key, 'title') and key.title:
+                print("%s %s" % (key.key, key.title or ''))
+            else:
+                print("%s" % key.key)
+
 
     @command
     def pull_request(self, opts):
@@ -1534,7 +1538,7 @@ will be ignored""" % (name, tag)
             for pkey in keys:
                 algo, key = pkey.key.split()[:2]
                 algo = algo[4:].upper()
-                if pkey.title:
+                if hasattr(pkey, 'title') and pkey.title:
                     print("%s key%s...%s (%s)" % (algo, ' ' * (6 - len(algo)), key[-10:], pkey.title))
                 else:
                     print("%s key%s...%s" % (algo, ' ' * (6 - len(algo)), key[-10:]))

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1087,7 +1087,8 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
         """[--enforcement-level=<level>] [--contexts=<contexts>] <branch>
            Protect a branch against deletions, force-pushes and failed status checks"""
         repo = self.repository(opts)
-        repo.branch(opts['<branch>']).protect(enforcement_level=opts['--enforcement-level'], contexts=(opts['--contexts'] or '').split(','))
+        repo.branch(opts['<branch>']).protect(enforcement=opts['--enforcement-level'],
+                                              status_checks=(opts['--contexts'] or '').split(','))
 
     @command
     def protected(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1503,7 +1503,7 @@ will be ignored""" % (name, tag)
             emails = {}
             if user.login == self.my_login:
                 for email in self.gh.emails():
-                    emails[str(email)] = email
+                    emails[email.email] = email
             print(wrap(user.name or user.login, attr.bright, attr.underline))
             print('Profile   %s' % user.html_url)
             if user.email:

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1087,11 +1087,11 @@ be ignored, the first line will be used as title for the issue.""" % (repo.owner
 
     @command
     def protect(self, opts):
-        """[--enforcement-level=<level>] [--contexts=<contexts>] <branch>
+        """[--enforcement=<level>] [--status_checks=<contexts>] <branch>
            Protect a branch against deletions, force-pushes and failed status checks"""
         repo = self.repository(opts)
-        repo.branch(opts['<branch>']).protect(enforcement=opts['--enforcement-level'],
-                                              status_checks=(opts['--contexts'] or '').split(','))
+        repo.branch(opts['<branch>']).protect(enforcement=opts['--enforcement'],
+                                              status_checks=(opts['--status_checks'] or '').split(','))
 
     @command
     def protected(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1508,16 +1508,14 @@ will be ignored""" % (name, tag)
             print('Profile   %s' % user.html_url)
             if user.email:
                 unverified = ''
-                user_email = emails.get(user.email)
-                if user_email is not None:
-                    if not user_email.verified:
-                        unverified = ' ' + wrap('(not verified)', fgcolor.red, attr.bright)
-                    print('Email     %s%s' % (user.email, unverified))
+                if user.email in emails and not emails[user.email].verified:
+                    unverified = ' ' + wrap('(not verified)', fgcolor.red, attr.bright)
+                print('Email     %s%s' % (user.email, unverified))
                 for email in emails:
                     if email == user.email:
                         continue
                     unverified = ''
-                    if not emails[email]['verified']:
+                    if not emails[email].verified:
                         unverified = ' ' + wrap('(not verified)', fgcolor.red, attr.bright)
                     print('          %s%s' % (email, unverified))
             if user.blog:

--- a/lib/gitspindle/monkey.py
+++ b/lib/gitspindle/monkey.py
@@ -8,16 +8,16 @@ glapi.Project.spindle = 'gitlab'
 glapi.UserProject.spindle = 'gitlab'
 
 # Monkeypatch github3.gists.Gist to behave more like a repo
-github3.gists.Gist.ssh_url = property(lambda self: 'git@gist.github.com:/%s.git' % self.id)
+github3.gists.Gist.ssh_url = property(lambda self: self.git_push_url)
 github3.gists.Gist.clone_url = property(lambda self: self.git_pull_url)
-github3.gists.Gist.git_url = property(lambda self: 'git://gist.github.com/%s.git' % self.id)
+github3.gists.Gist.git_url = property(lambda self: self.git_pull_url)
 github3.gists.Gist.name = property(lambda self: self.id)
 github3.gists.Gist.private = property(lambda self: not self.public)
 github3.gists.Gist.create_fork = github3.gists.Gist.fork
 # XXX - There is nothing in the API output that indicates forkedness
 github3.gists.Gist.fork = False
-github3.gists.Gist.iter_issues = lambda self, *args, **kwargs: []
-def _iter_gist_events(self, number=300):
+github3.gists.Gist.issues = lambda self, *args, **kwargs: []
+def _gist_events(self, number=300):
     for event in self.history[:number]:
         yield GistEvent(event, self)
 class GistEvent(object):
@@ -30,16 +30,16 @@ class GistEvent(object):
         if not self.actor.login:
             self.actor = gist.owner
         self.repo = ('gist', gist.name)
-github3.gists.Gist.iter_events = _iter_gist_events
+github3.gists.Gist.events = _gist_events
 class Content(object):
     def __init__(self, file):
-        self.decoded = file.content
+        self.decoded = file.content()
 def _gist_contents(self, path, ref):
     # XXX ignore ref for now, can't do much with it
-    for f in self.iter_files():
+    for f in self.files():
         if f.filename == path:
             return Content(f)
-github3.gists.Gist.contents = _gist_contents
+github3.gists.Gist.file_contents = _gist_contents
 
 # Monkeypatch github3.session.request to warn when approaching rate limits
 from github3.session import GitHubSession

--- a/lib/gitspindle/monkey.py
+++ b/lib/gitspindle/monkey.py
@@ -8,9 +8,9 @@ glapi.Project.spindle = 'gitlab'
 glapi.UserProject.spindle = 'gitlab'
 
 # Monkeypatch github3.gists.Gist to behave more like a repo
-github3.gists.Gist.ssh_url = property(lambda self: self.git_push_url)
+github3.gists.Gist.ssh_url = property(lambda self: 'git@gist.github.com:/%s.git' % self.id)
 github3.gists.Gist.clone_url = property(lambda self: self.git_pull_url)
-github3.gists.Gist.git_url = property(lambda self: self.git_pull_url)
+github3.gists.Gist.git_url = property(lambda self: 'git://gist.github.com/%s.git' % self.id)
 github3.gists.Gist.name = property(lambda self: self.id)
 github3.gists.Gist.private = property(lambda self: not self.public)
 github3.gists.Gist.create_fork = github3.gists.Gist.fork

--- a/lib/gitspindle/monkey.py
+++ b/lib/gitspindle/monkey.py
@@ -8,15 +8,15 @@ glapi.Project.spindle = 'gitlab'
 glapi.UserProject.spindle = 'gitlab'
 
 # Monkeypatch github3.gists.Gist to behave more like a repo
-github3.gists.Gist.ssh_url = property(lambda self: 'git@gist.github.com:/%s.git' % self.id)
-github3.gists.Gist.clone_url = property(lambda self: self.git_pull_url)
-github3.gists.Gist.git_url = property(lambda self: 'git://gist.github.com/%s.git' % self.id)
-github3.gists.Gist.name = property(lambda self: self.id)
-github3.gists.Gist.private = property(lambda self: not self.public)
-github3.gists.Gist.create_fork = github3.gists.Gist.fork
+github3.gists.gist._Gist.ssh_url = property(lambda self: 'git@gist.github.com:/%s.git' % self.id)
+github3.gists.gist._Gist.clone_url = property(lambda self: self.git_pull_url)
+github3.gists.gist._Gist.git_url = property(lambda self: 'git://gist.github.com/%s.git' % self.id)
+github3.gists.gist._Gist.name = property(lambda self: self.id)
+github3.gists.gist._Gist.private = property(lambda self: not self.public)
+github3.gists.gist._Gist.create_fork = github3.gists.Gist.fork
 # XXX - There is nothing in the API output that indicates forkedness
-github3.gists.Gist.fork = False
-github3.gists.Gist.issues = lambda self, *args, **kwargs: []
+github3.gists.gist._Gist.fork = False
+github3.gists.gist._Gist.issues = lambda self, *args, **kwargs: []
 def _gist_events(self, number=300):
     for event in self.history[:number]:
         yield GistEvent(event, self)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(name='git-spindle',
         "Topic :: Software Development",
         "Topic :: Software Development :: Version Control"
     ],
-    install_requires=["github3.py>=1.0.0,<=1.1", "whelk>=2.6", "docopt>=0.5.0", "six"],
+    install_requires=["github3.py>=1.1.0", "whelk>=2.6", "docopt>=0.5.0", "six"],
 )

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(name='git-spindle',
         "Topic :: Software Development",
         "Topic :: Software Development :: Version Control"
     ],
-    install_requires=["github3.py>=0.9.0,<1.0","whelk>=2.6", "docopt>=0.5.0", "six"],
+    install_requires=["github3.py>=1.0.0,<=1.1", "whelk>=2.6", "docopt>=0.5.0", "six"],
 )


### PR DESCRIPTION
I wanted to package git-spindle for the Arch Linux User Repository
(AUR). Since on AUR there is version 1.0.0a2 of github3.py, I started
porting git spindle to that version of the library.

Currently I use my fork for packaging git-spindle on AUR, and opened
this PR so you can track the changes, and merge it when the time comes. 

I see no sane way to keep compatibility with both 0.9 and 1.0 versions
of github3.py.
