### PR TITLE
add support for configuring triangular workflows

### DIFF
--- a/README
+++ b/README
@@ -58,7 +58,7 @@ Display the contents of a file on GitHub:
 Check the github pages configuration and content of your repo:
   git hub check-pages
 Clone a repository by name:
-  git hub clone [--ssh|--http|--git] [--parent] [git-clone-options] <repo> [<dir>]
+  git hub clone [--ssh|--http|--git] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
 List collaborators of a repository:
   git hub collaborators [<repo>]
 Configure git-spindle, similar to git-config:
@@ -74,7 +74,7 @@ Edit a hook:
 Fetch refs from a user's fork:
   git hub fetch [--ssh|--http|--git] <user> [<refspec>]
 Fork a repo and clone it:
-  git hub fork [--ssh|--http|--git] [<repo>]
+  git hub fork [--ssh|--http|--git] [--triangular] [<repo>]
 List all forks of this repository:
   git hub forks [<repo>]
 Create a new gist from files or stdin:
@@ -126,7 +126,7 @@ List all repos of a user, by default yours:
 Let the octocat speak to you:
   git hub say [<msg>]
 Set the remote 'origin' to github.:
-  git hub set-origin [--ssh|--http|--git]
+  git hub set-origin [--ssh|--http|--git] [--triangular]
 Set up goblet config based on GitHub config:
   git hub setup-goblet
 Display current and historical GitHub service status:
@@ -155,7 +155,7 @@ Show a timeline of a user's activity:
 Display the contents of a file on GitLab:
   git lab cat <file>...
 Clone a repository by name:
-  git lab clone [--ssh|--http] [--parent] [git-clone-options] <repo> [<dir>]
+  git lab clone [--ssh|--http] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
 Configure git-spindle, similar to git-config:
   git lab config [--unset] <key> [<value>]
 Create a repository on gitlab to push to:
@@ -163,7 +163,7 @@ Create a repository on gitlab to push to:
 Fetch refs from a user's fork:
   git lab fetch [--ssh|--http] <user> [<refspec>]
 Fork a repo and clone it:
-  git lab fork [--ssh|--http] [<repo>]
+  git lab fork [--ssh|--http] [--triangular] [<repo>]
 Show issue details or report an issue:
   git lab issue [<repo>] [--parent] [<issue>...]
 List issues in a repository:
@@ -189,7 +189,7 @@ Remove a user's membership:
 List all your repos:
   git lab repos [--no-forks]
 Set the remote 'origin' to gitlab.:
-  git lab set-origin [--ssh|--http]
+  git lab set-origin [--ssh|--http] [--triangular]
 Remove force-push protection from a branch:
   git lab unprotect <branch>
 Display GitLab user info:
@@ -214,7 +214,7 @@ Open the GitHub page for a repository in a browser:
 Display the contents of a file on BitBucket:
   git bb cat <file>...
 Clone a repository by name:
-  git bb clone [--ssh|--http] [--parent] [git-clone-options] <repo> [<dir>]
+  git bb clone [--ssh|--http] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
 Configure git-spindle, similar to git-config:
   git bb config [--unset] <key> [<value>]
 Create a repository on bitbucket to push to:
@@ -224,7 +224,7 @@ Lists all keys for a repo:
 Fetch refs from a user's fork:
   git bb fetch [--ssh|--http] <user> [<refspec>]
 Fork a repo and clone it:
-  git bb fork [--ssh|--http] [<repo>]
+  git bb fork [--ssh|--http] [--triangular] [<repo>]
 List all forks of this repository:
   git bb forks [<repo>]
 Invite users to collaborate on this repository:
@@ -250,7 +250,7 @@ Remove a user's privileges:
 List all repos of a user, by default yours:
   git bb repos [--no-forks] [<user>]
 Set the remote 'origin' to github.:
-  git bb set-origin [--ssh|--http]
+  git bb set-origin [--ssh|--http] [--triangular]
 Create a new snippet from files or stdin:
   git bb snippet [--description=<description>] <file>...
 Show all snippets for a user:

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -77,20 +77,31 @@ will be created on BitBucket and your local repository will have BitBucket as re
 By default the repository is created under your account, but you can specify a
 team to create the repository for.
 
-.. describe:: git bb set-origin [--ssh|--http]
+.. describe:: git bb set-origin [--ssh|--http] [--triangular]
 
-Fix the configuration of your repository's remotes. Remote "origin" will be set
-to your BitBucket repository. If that repository is a fork, remote "upstream" will
-be set to the repository you forked from.
+Fix the configuration of your repository's remotes. The remote "origin" will be
+set to your BitBucket repository. If "origin" is a fork, an "upstream" remote will
+be set to the repository you forked from. If "origin" is not a fork, a fetch
+refspec is added to fetch the pull requests for "origin" as
+`refs/pull/<id>/head`.
 
-For origin, an SSH url is used. For upstream, set-origin defaults to adding an
-http url, but this can be overridden. For private repos SSH is used.
+All non-tracking branches with a matching counterpart in "origin" will be set to
+track "origin" (push and pull to it). Use :option:`--triangular` to set remotes
+in a triangular fashion where :command:`git pull` pulls from "upstream" and
+:command:`git push` pushes to "origin".
 
-.. describe:: git bb clone [--ssh|--http] [--parent] [git-clone-options] <repo> [<dir>]
+For "origin", an SSH url is used. For "upstream", set-origin defaults to adding
+a git url, but this can be overridden. For private repos, SSH is used.
 
-Clone a BitBucket repository by name (e.g. seveas/whelk) or URL. If it's a fork,
-the "upstream" origin will be set up too. Defaults to cloning from an http url,
-but this can be overridden. For private repos SSH is used.
+.. describe:: git bb clone [--ssh|--http] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
+
+Clone a BitBucket repository by name (e.g. seveas/whelk) or URL. The "origin"
+remote will be set and, like with set-origin, if "origin" is a fork the
+"upstream" remote will be set too. The option :option:`--triangular` can be used
+for a triangular setup.
+
+Defaults to cloning from a git url, but this can be overridden. For private
+repos, SSH is used.
 
 This command accepts all options git clone accepts and will forward those to
 :command:`git clone`.
@@ -107,11 +118,14 @@ Display the contents of a directory on BitBucket. Directory can start with
 repository names and refs. For example: `master:bin/git-bb`,
 `git-spindle:master:bin/git-bb` or `seveas/git-spindle:master:bin/git-bb`.
 
-.. describe:: git bb fork [--ssh|--http] [<repo>]
+.. describe:: git bb fork [--ssh|--http] [--triangular] [<repo>]
 
 Fork another person's git repository on BitBucket and clone that repository
-locally. Repo can be specified as a (git) url or simply username/repo. Like
-with set-origin, the "origin" and "upstream" remotes will be set up too.
+locally. The repository can be specified as a (git) url or simply username/repo.
+Like with set-origin, the "origin" and "upstream" remotes will be set up too.
+The option :option:`--triangular` can be used for a triangular setup.
+
+Defaults to cloning from a git url, but this can be overridden.
 
 Calling fork in a previously cloned-but-not-forked repository will create a
 fork of that repository and set up your remotes.

--- a/docs/github.rst
+++ b/docs/github.rst
@@ -143,20 +143,31 @@ will be created on GitHub and your local repository will have GitHub as remote
 By default the repository is created under your account, but you can specify an
 organization to create the repository for.
 
-.. describe:: git hub set-origin [--ssh|--http|--git]
+.. describe:: git hub set-origin [--ssh|--http|--git] [--triangular]
 
-Fix the configuration of your repository's remotes. Remote "origin" will be set
-to your GitHub repository. If that repository is a fork, remote "upstream" will
-be set to the repository you forked from.
+Fix the configuration of your repository's remotes. The remote "origin" will be
+set to your GitHub repository. If "origin" is a fork, an "upstream" remote will
+be set to the repository you forked from. If "origin" is not a fork, a fetch
+refspec is added to fetch the pull requests for "origin" as
+`refs/pull/<id>/head`.
 
-For origin, an SSH url is used. For upstream, set-origin defaults to adding a
-git url, but this can be overridden. For private repos SSH is used.
+All non-tracking branches with a matching counterpart in "origin" will be set to
+track "origin" (push and pull to it). Use :option:`--triangular` to set remotes
+in a triangular fashion where :command:`git pull` pulls from "upstream" and
+:command:`git push` pushes to "origin".
+
+For "origin", an SSH url is used. For "upstream", set-origin defaults to adding
+a git url, but this can be overridden. For private repos, SSH is used.
 
 .. describe:: git hub clone [--ssh|--http|--git] [--parent] [git-clone-options] <repo> [<dir>]
 
-Clone a GitHub repository by name (e.g. seveas/hacks) or URL. If it's a fork,
-the "upstream" origin will be set up too. Defaults to cloning from a git url,
-but this can be overridden. For private repos SSH is used.
+Clone a GitHub repository by name (e.g. seveas/hacks) or URL. The "origin"
+remote will be set and, like with set-origin, if "origin" is a fork an
+"upstream" remote will be set too. The option :option:`--triangular` can be used
+for a triangular setup.
+
+Defaults to cloning from a git url, but this can be overridden. For private
+repos, SSH is used.
 
 This command accepts all options git clone accepts and will forward those to
 :command:`git clone`.
@@ -180,8 +191,12 @@ Download and display a repository's README file, whatever its actual name is.
 .. describe:: git hub fork [--ssh|--http|--git] [<repo>]
 
 Fork another person's git repository on GitHub and clone that repository
-locally. Repo can be specified as a (git) url or simply username/repo. Like
-with set-origin, the "origin" and "upstream" remotes will be set up too.
+locally. The repository can be specified as a (git) url or simply username/repo.
+Like with set-origin, the "origin" and "upstream" remotes will be set up too.
+The option :option:`--triangular` can be used for a triangular setup.
+
+Defaults to cloning from a git url, but this can be overridden. For private
+repos, SSH is used.
 
 Calling fork in a previously cloned-but-not-forked repository will create a
 fork of that repository and set up your remotes.

--- a/docs/gitlab.rst
+++ b/docs/gitlab.rst
@@ -105,20 +105,31 @@ have GitLab as remote "origin", so :command:`git push origin master` will work.
 By default the repository is created under your account, but you can specify a
 group to create the repository for.
 
-.. describe:: git lab set-origin [--ssh|--http]
+.. describe:: git lab set-origin [--ssh|--http] [--triangular]
 
-Fix the configuration of your repository's remotes. Remote "origin" will be set
-to your GitLab repository. If that repository is a fork, remote "upstream" will
-be set to the repository you forked from.
+Fix the configuration of your repository's remotes. The remote "origin" will be
+set to your GitLab repository. If "origin" is a fork, an "upstream" remote will
+be set to the repository you forked from. If "origin" is not a fork, a fetch
+refspec is added to fetch the pull requests for "origin" as
+`refs/pull/<id>/head`.
 
-For origin, an SSH url is used. For upstream, set-origin defaults to adding an
-http url, but this can be overridden. For non-public repos SSH is used.
+All non-tracking branches with a matching counterpart in "origin" will be set to
+track "origin" (push and pull to it). Use :option:`--triangular` to set remotes
+in a triangular fashion where :command:`git pull` pulls from "upstream" and
+:command:`git push` pushes to "origin".
 
-.. describe:: git lab clone [--ssh|--http] [--parent] [git-clone-options] <repo> [<dir>]
+For "origin", an SSH url is used. For "upstream", set-origin defaults to adding
+a git url, but this can be overridden. For private repos, SSH is used.
 
-Clone a GitLab repository by name (e.g. seveas/hacks) or URL. If it's a fork,
-the "upstream" origin will be set up too. Defaults to cloning from an http url,
-but this can be overridden. For non-public repos SSH is used.
+.. describe:: git lab clone [--ssh|--http] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
+
+Clone a GitLab repository by name (e.g. seveas/hacks) or URL. The "origin"
+remote will be set and, like with set-origin, if "origin" is a fork t
+"upstream" remote will be set too. The option :option:`--triangular` can be used
+for a triangular setup.
+
+Defaults to cloning from an http url, but this can be overridden. For private
+repos, SSH is used.
 
 This command accepts all options git clone accepts and will forward those to
 :command:`git clone`.
@@ -135,11 +146,14 @@ Display the contents of a directory on GitLab. Directory can start with
 repository names and refs. For example: `master:bin/git-lab`,
 `git-spindle:master:bin/git-lab` or `seveas/git-spindle:master:bin/git-lab`.
 
-.. describe:: git lab fork [--ssh|--http] [<repo>]
+.. describe:: git lab fork [--ssh|--http] [--triangular] [<repo>]
 
 Fork another person's git repository on GitLab and clones that repository
-locally. Repo can be specified as a (git) url or simply username/repo. Like
-with set-origin, the "origin" and "upstream" remotes will be set up too.
+locally. Repo can be specified as a (git) url or simply username/repo. Like with
+set-origin, the "origin" and "upstream" remotes will be set up too. The option
+:option:`--triangular` can be used for a triangular setup.
+
+Defaults to cloning from a git url, but this can be overridden.
 
 Calling fork in a previously cloned-but-not-forked repository will create a
 fork of that repository and set up your remotes.

--- a/lib/gitspindle/bitbucket.py
+++ b/lib/gitspindle/bitbucket.py
@@ -197,7 +197,7 @@ class BitBucket(GitSpindle):
 
     @command
     def clone(self, opts, repo=None):
-        """[--ssh|--http] [--parent] [git-clone-options] <repo> [<dir>]
+        """[--ssh|--http] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
            Clone a repository by name"""
         if not repo:
             repo = self.repository(opts)
@@ -264,7 +264,7 @@ class BitBucket(GitSpindle):
 
     @command
     def fork(self, opts):
-        """[--ssh|--http] [<repo>]
+        """[--ssh|--http] [--triangular] [<repo>]
            Fork a repo and clone it"""
         do_clone = bool(opts['<repo>'])
         repo = self.repository(opts)
@@ -605,7 +605,7 @@ class BitBucket(GitSpindle):
 
     @command
     def set_origin(self, opts, repo=None, remote='origin'):
-        """[--ssh|--http]
+        """[--ssh|--http] [--triangular]
            Set the remote 'origin' to github.
            If this is a fork, set the remote 'upstream' to the parent"""
         if not repo:
@@ -639,13 +639,7 @@ class BitBucket(GitSpindle):
         if remote != 'origin':
             return
 
-        for branch in self.git('for-each-ref', 'refs/heads/**').stdout.strip().splitlines():
-            branch = branch.split(None, 2)[-1][11:]
-            if self.git('for-each-ref', 'refs/remotes/origin/%s' % branch).stdout.strip():
-                if self.git('config', 'branch.%s.remote' % branch).returncode != 0:
-                    print("Marking %s as remote-tracking branch" % branch)
-                    self.gitm('config', 'branch.%s.remote' % branch, 'origin')
-                    self.gitm('config', 'branch.%s.merge' % branch, 'refs/heads/%s' % branch)
+        self.set_tracking_branches(remote, upstream="upstream", triangular=opts['--triangular'])
 
     @command
     def snippet(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -501,7 +501,7 @@ class GitHub(GitSpindle):
 
     @command
     def clone(self, opts, repo=None):
-        """[--ssh|--http|--git] [--parent] [git-clone-options] <repo> [<dir>]
+        """[--ssh|--http|--git] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
            Clone a repository by name"""
         if not repo:
             repo = self.repository(opts)
@@ -638,7 +638,7 @@ class GitHub(GitSpindle):
 
     @command
     def fork(self, opts):
-        """[--ssh|--http|--git] [<repo>]
+        """[--ssh|--http|--git] [--triangular] [<repo>]
            Fork a repo and clone it"""
         do_clone = bool(opts['<repo>'])
         repo = self.repository(opts)
@@ -1356,7 +1356,7 @@ class GitHub(GitSpindle):
 
     @command
     def set_origin(self, opts, repo=None, remote='origin'):
-        """[--ssh|--http|--git]
+        """[--ssh|--http|--git] [--triangular]
            Set the remote 'origin' to github.
            If this is a fork, set the remote 'upstream' to the parent"""
         if not repo:
@@ -1397,13 +1397,7 @@ class GitHub(GitSpindle):
         if remote != 'origin':
             return
 
-        for branch in self.git('for-each-ref', 'refs/heads/**').stdout.strip().splitlines():
-            branch = branch.split(None, 2)[-1][11:]
-            if self.git('for-each-ref', 'refs/remotes/origin/%s' % branch).stdout.strip():
-                if self.git('config', 'branch.%s.remote' % branch).returncode != 0:
-                    print("Marking %s as remote-tracking branch" % branch)
-                    self.gitm('config', 'branch.%s.remote' % branch, 'origin')
-                    self.gitm('config', 'branch.%s.merge' % branch, 'refs/heads/%s' % branch)
+        self.set_tracking_branches(remote, upstream="upstream", triangular=opts['--triangular'])
 
     @command
     def status(self, opts):

--- a/lib/gitspindle/gitlab.py
+++ b/lib/gitspindle/gitlab.py
@@ -356,7 +356,7 @@ class GitLab(GitSpindle):
 
     @command
     def clone(self, opts, repo=None):
-        """[--ssh|--http] [--parent] [git-clone-options] <repo> [<dir>]
+        """[--ssh|--http] [--triangular] [--parent] [git-clone-options] <repo> [<dir>]
            Clone a repository by name"""
         if not repo:
             repo = self.repository(opts)
@@ -422,7 +422,7 @@ class GitLab(GitSpindle):
 
     @command
     def fork(self, opts):
-        """[--ssh|--http] [<repo>]
+        """[--ssh|--http] [--triangular] [<repo>]
            Fork a repo and clone it"""
         do_clone = bool(opts['<repo>'])
         repo = self.repository(opts)
@@ -784,7 +784,7 @@ class GitLab(GitSpindle):
 
     @command
     def set_origin(self, opts, repo=None, remote='origin'):
-        """[--ssh|--http]
+        """[--ssh|--http] [--triangular]
            Set the remote 'origin' to gitlab.
            If this is a fork, set the remote 'upstream' to the parent"""
         if not repo:
@@ -819,13 +819,7 @@ class GitLab(GitSpindle):
         if remote != 'origin':
             return
 
-        for branch in self.git('for-each-ref', 'refs/heads/**').stdout.strip().splitlines():
-            branch = branch.split(None, 2)[-1][11:]
-            if self.git('for-each-ref', 'refs/remotes/origin/%s' % branch).stdout.strip():
-                if self.git('config', 'branch.%s.remote' % branch).returncode != 0:
-                    print("Marking %s as remote-tracking branch" % branch)
-                    self.gitm('config', 'branch.%s.remote' % branch, 'origin')
-                    self.gitm('config', 'branch.%s.merge' % branch, 'refs/heads/%s' % branch)
+        self.set_tracking_branches(remote, upstream="upstream", triangular=opts['--triangular'])
 
     @command
     def unprotect(self, opts):

--- a/test/204_set_origin.t
+++ b/test/204_set_origin.t
@@ -10,13 +10,29 @@ test_expect_success "Cloning repository" "
 "
 
 for spindle in lab hub bb; do
+    test_expect_success $spindle "Setting triangular origin to $spindle" "
+        (cd whelk &&
+        host=\$(spindle_host git_${spindle}_2) &&
+        git branch --unset-upstream master &&
+        git_${spindle}_2 set-origin --triangular &&
+        git remote -v &&
+        git config remote.origin.url | grep -q git@\$host &&
+        git config remote.upstream.url | grep -q \"https://\\(.*@\\)\\?\$host\" &&
+        git config branch.master.remote | grep -q \"upstream\" &&
+        git config branch.master.pushremote | grep -q \"origin\")
+    "
+done
+
+for spindle in lab hub bb; do
     test_expect_success $spindle "Setting origin to $spindle" "
         (cd whelk &&
         host=\$(spindle_host git_${spindle}_2) &&
+        git branch --unset-upstream master &&
         git_${spindle}_2 set-origin &&
         git remote -v &&
         git config remote.origin.url | grep -q git@\$host &&
-        git config remote.upstream.url | grep -q \"https://\\(.*@\\)\\?\$host\")
+        git config remote.upstream.url | grep -q \"https://\\(.*@\\)\\?\$host\" &&
+        git config branch.master.remote | grep -q \"origin\")
     "
 done
 


### PR DESCRIPTION
This commit adds the `--triangular` option to set-origin, that sets all
matching branches tracking upstream, and configures origin as a pushremote.