### PR TITLE
Be more robust when splitting a key

### DIFF
--- a/lib/gitspindle/bitbucket.py
+++ b/lib/gitspindle/bitbucket.py
@@ -698,7 +698,7 @@ class BitBucket(GitSpindle):
             except bbapi.BitBucketError:
                 keys = []
             for pkey in keys:
-                algo, key = pkey.key.split()
+                algo, key = pkey.key.split()[:2]
                 algo = algo[4:].upper()
                 if pkey.label:
                     print("%s key%s...%s (%s)" % (algo, ' ' * (6 - len(algo)), key[-10:], pkey.label))

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -1480,7 +1480,7 @@ class GitHub(GitSpindle):
             else:
                 keys = user.iter_keys()
             for pkey in keys:
-                algo, key = pkey.key.split()
+                algo, key = pkey.key.split()[:2]
                 algo = algo[4:].upper()
                 if pkey.title:
                     print("%s key%s...%s (%s)" % (algo, ' ' * (6 - len(algo)), key[-10:], pkey.title))


### PR DESCRIPTION
On bitbucket my key returned the key title as a third item, and the
value unpacking failed.