### PR TITLE
fix requesting and output of issues

### DIFF
--- a/lib/gitspindle/bbapi.py
+++ b/lib/gitspindle/bbapi.py
@@ -154,6 +154,11 @@ def ssh_fix(url):
 class PullRequest(BBobject):
     uri = 'https://api.bitbucket.org/2.0/repositories/{owner}/{slug}/pullrequests/{id}'
 
+    def get_url(self):
+        return self.links['html']['href']
+
+    html_url = property(get_url)
+
 class Repository(BBobject):
     uri = ('https://bitbucket.org/api/1.0/repositories/{owner}/{slug}',
            'https://bitbucket.org/api/2.0/repositories/{owner}/{slug}')
@@ -202,8 +207,8 @@ class Repository(BBobject):
         return [Repository(self.bb, mode=None, **repo) for repo in data]
 
     def issues(self, **params):
-        url = 'https://bitbucket.org/api/1.0/repositories/%s/issues' % self.full_name
-        data = self.get(url, data=params)['issues']
+        url = 'https://bitbucket.org/api/2.0/repositories/%s/issues' % self.full_name
+        data = self.get(url, data=params)['values']
         return [Issue(self.bb, mode=None, **issue) for issue in data]
 
     def issue(self, id):
@@ -213,7 +218,7 @@ class Repository(BBobject):
         data = {'title': title, 'content': body}
         issue = self.post(self.url[0] + '/issues', data=data)
         issue['repo'] = self
-        return Issue(self.bb, mode=None, **issue)
+        return Issue(self.bb, owner=self.owner['username'], slug=self.slug, id=issue['local_id'], repo=self)
 
     def src(self, revision, path):
         return Source(self.bb, owner=self.owner['username'], slug=self.slug, revision=revision, path=path.split('/'))
@@ -268,10 +273,10 @@ class Key(BBobject):
         self.delete_(self.url[0] + '/%d' % self.pk)
 
 class Issue(BBobject):
-    uri = 'https://bitbucket.org/api/1.0/repositories/{owner}/{slug}/issues/{id}'
+    uri = 'https://bitbucket.org/api/2.0/repositories/{owner}/{slug}/issues/{id}'
 
     def get_url(self):
-        return 'https://bitbucket.org/%s/%s/issue/%s/' % (self.repo.owner['username'], self.repo.slug, self.local_id)
+        return self.links['html']['href']
 
     html_url = property(get_url)
 

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -758,11 +758,14 @@ class GitHub(GitSpindle):
             # Let's assume it's an issue
             opts['<issue>'].insert(0, opts['<repo>'])
         repo = self.repository(opts)
-        for issue in opts['<issue>']:
-            issue = repo.issue(issue)
-            print(wrap(issue.title, attr.bright, attr.underline))
-            print(issue.body)
-            print(issue.pull_request and issue.pull_request['html_url'] or issue.html_url)
+        for issue_no in opts['<issue>']:
+            issue = repo.issue(issue_no)
+            if issue:
+                print(wrap(issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), attr.bright, attr.underline))
+                print(issue.body.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding))
+                print(issue.pull_request and issue.pull_request['html_url'] or issue.html_url)
+            else:
+                print('No issue with id %s found in repository %s' % (issue_no, repo.full_name))
         if not opts['<issue>']:
             body = self.find_template(repo, 'ISSUE_TEMPLATE') or """
 # Reporting an issue on %s/%s
@@ -807,7 +810,7 @@ class GitHub(GitSpindle):
             print(wrap("Issues for %s/%s" % (repo.owner.login, repo.name), attr.bright))
             for issue in issues:
                 url = issue.pull_request and issue.pull_request['html_url'] or issue.html_url
-                print("[%d] %s %s" % (issue.number, issue.title, url))
+                print("[%d] %s %s" % (issue.number, issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), url))
 
     @command
     def log(self, opts):

--- a/lib/gitspindle/gitlab.py
+++ b/lib/gitspindle/gitlab.py
@@ -127,10 +127,6 @@ class GitLab(GitSpindle):
     def profile_url(self, user):
         return '%s/u/%s' % (self.host, user.username)
 
-    def issue_url(self, issue):
-        repo = self.gl.Project(issue.project_id)
-        return '%s/issues/%d' % (repo.web_url, issue.iid)
-
     def merge_url(self, merge):
         repo = self.gl.Project(merge.project_id)
         return '%s/merge_requests/%d' % (repo.web_url, merge.iid)
@@ -448,14 +444,15 @@ class GitLab(GitSpindle):
             # Let's assume it's an issue
             opts['<issue>'].insert(0, opts['<repo>'])
         repo = self.repository(opts)
-        # There's no way to fetch an issue by iid. Abuse search.
-        issues = repo.Issue()
-        for issue in opts['<issue>']:
-            issue = int(issue)
-            issue = [x for x in issues if x.iid == issue][0]
-            print(wrap(issue.title, attr.bright, attr.underline))
-            print(issue.description)
-            print(self.issue_url(issue))
+        for issue_no in opts['<issue>']:
+            issues = repo.Issue(iid=issue_no)
+            if len(issues):
+                issue = issues[0]
+                print(wrap(issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), attr.bright, attr.underline))
+                print(issue.description.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding))
+                print(issue.web_url)
+            else:
+                print('No issue with id %s found in repository %s' % (issue_no, repo.path_with_namespace))
         if not opts['<issue>']:
             body = """
 # Reporting an issue on %s/%s
@@ -469,7 +466,7 @@ class GitLab(GitSpindle):
             try:
                 issue = glapi.ProjectIssue(self.gl, {'project_id': repo.id, 'title': title, 'description': body})
                 issue.save()
-                print("Issue %d created %s" % (issue.iid, self.issue_url(issue)))
+                print("Issue %d created %s" % (issue.iid, issue.web_url))
             except:
                 filename = self.backup_message(title, body, 'issue-message-')
                 err("Failed to create an issue, the issue text has been saved in %s" % filename)
@@ -493,11 +490,11 @@ class GitLab(GitSpindle):
             if issues:
                 print(wrap("Issues for %s/%s" % (repo.namespace.path, repo.path), attr.bright))
                 for issue in issues:
-                    print("[%d] %s %s" % (issue.iid, issue.title, self.issue_url(issue)))
+                    print("[%d] %s %s" % (issue.iid, issue.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), issue.web_url))
             if mergerequests:
                 print(wrap("Merge requests for %s/%s" % (repo.namespace.path, repo.path), attr.bright))
                 for mr in mergerequests:
-                    print("[%d] %s %s" % (mr.iid, mr.title, self.merge_url(mr)))
+                    print("[%d] %s %s" % (mr.iid, mr.title.encode(sys.stdout.encoding, errors='backslashreplace').decode(sys.stdout.encoding), self.merge_url(mr)))
 
     @command
     def log(self, opts):

--- a/test/401_issues.t
+++ b/test/401_issues.t
@@ -48,6 +48,24 @@ for spindle in lab hub bb; do
         grep -q whelk issues
     "
 
+    test_expect_success $spindle "Display non-existing issue ($spindle)" "
+        git_${spindle}_1 issue whelk 999 > issue &&
+        grep -q '^No issue with id 999 found in repository $(username git_${spindle}_1)/whelk$' issue
+    "
+
+    export FAKE_EDITOR_DATA="Test issue with umlaut ö $id\n\nThis is a test issue with umlaut ö done by git-spindle's test suite\n"
+    test_expect_success $spindle "Display issue with special character in title and body ($spindle)" "
+        (cd whelk &&
+        LC_ALL=en_US.UTF-8 git_${spindle}_1 issue &&
+        echo -n 'Testing with UTF-8 to make sure the issue was created correctly ... ' &&
+        PYTHONIOENCODING=utf-8 git_${spindle}_1 issues > issues &&
+        grep -q 'Test issue with umlaut ö $id' issues &&
+        echo -n 'OK\nTesting with ascii to make sure the output escaping is done correctly ... ' &&
+        PYTHONIOENCODING=ascii git_${spindle}_1 issues > issues &&
+        grep -q 'Test issue with umlaut \\\\xf6 $id' issues &&
+        echo 'OK')
+    "
+
     test_expect_failure $spindle "Display single issue" "false"
 done
 


### PR DESCRIPTION
- use BitBucket API v2 to retrieve issues, this give a ready-made web link
- fix encoding of issue titles and bodies in case of non-utf-8 terminal like on windows
- gracefully display if an issue cannot be found
- do not iterate over all GitLab issues to find one specific, but request only that one directly