### PR TITLE
wait for deletion to complete for create and fork

### DIFF
--- a/lib/gitspindle/gitlab.py
+++ b/lib/gitspindle/gitlab.py
@@ -395,7 +395,22 @@ class GitLab(GitSpindle):
                 err("Group %s could not be found" % opts['--group'])
             kwargs['namespace_id'] = group.id
         repo = glapi.Project(self.gl, kwargs)
-        repo.save()
+        i = 0
+        success = False
+        while not success:
+            try:
+                repo.save()
+                success = True
+            except glapi.GitlabCreateError as gce:
+                i += 1
+                time.sleep(1)
+                if (gce.response_code != 400) \
+                        or (not isinstance(gce.error_message, dict)) \
+                        or (not 'base' in gce.error_message) \
+                        or (not isinstance(gce.error_message['base'], list)) \
+                        or (not 'The project is still being deleted. Please try again later.' in gce.error_message['base']) \
+                        or (i >= 120):
+                    raise
         if 'origin' in self.remotes():
             print("Remote 'origin' already exists, adding the GitLab repository as 'gitlab'")
             self.set_origin(opts, repo=repo, remote='gitlab')
@@ -433,7 +448,22 @@ class GitLab(GitSpindle):
         if my_repo:
             err("Repository already exists")
 
-        my_fork = repo.fork()
+        i = 0
+        success = False
+        while not success:
+            try:
+                my_fork = repo.fork()
+                success = True
+            except glapi.GitlabForkError as gfe:
+                i += 1
+                time.sleep(1)
+                if (gfe.response_code != 409) \
+                        or (not isinstance(gfe.error_message, dict)) \
+                        or (not 'base' in gfe.error_message) \
+                        or (not isinstance(gfe.error_message['base'], list)) \
+                        or (not 'The project is still being deleted. Please try again later.' in gfe.error_message['base']) \
+                        or (i >= 120):
+                    raise
 
         if do_clone:
             self.clone(opts, repo=my_fork)


### PR DESCRIPTION
If you try to create or fork a repository, while the old repository at those coordinates is still being deleted on GitLab due to its asynchronous working mode, the operation fails with an according error message from GitLab.
It is now tried for 120 times, waiting a second between the tries to repeat the operation if it fails due to that exact reason.
An end-user would see the recommendation to try again later and could do so manually, but this way it is more convenient.
Where this change is important and essential, are the tests. Since a recent update to GitLab, the tests almost never run through due to this behavior. With this change they are working again.