### PR TITLE
Fix using a plain domain name as a host

### DIFF
--- a/lib/gitspindle/__init__.py
+++ b/lib/gitspindle/__init__.py
@@ -327,7 +327,11 @@ Options:
         os.environ['GITSPINDLE_ACCOUNT'] = self.account or self.spindle
         host = self.config('host')
         if host:
-            self.hosts = [urlparse.urlparse(host).hostname]
+            url = host
+            if '://' not in url:
+                # SSH url, transform to ssh:// syntax
+                url = 'ssh://' + url.replace(':', '/')
+            self.hosts = [urlparse.urlparse(url).hostname]
 
         for command, func in self.commands.items():
             if opts[command]:


### PR DESCRIPTION
If the host is a plain domain name, it was failing parsing, and setting self.hosts to `[None]`

This mostly didn't have effects, but caused a problem if the name of the current directory isn't the same as the name of the repository on gitlab. In this case, the server name not matching the host would cause the repository _parse_url to fail because of the lack of host matching, falling back to the current directory name. So adding a remote would fail.