### PR TITLE
Fix for crash upon gitlab.py error (fix for issue #169)

### DIFF
--- a/lib/gitspindle/gitlab.py
+++ b/lib/gitspindle/gitlab.py
@@ -10,7 +10,7 @@ import os
 import requests
 import sys
 import webbrowser
-
+import time
 
 class GitLab(GitSpindle):
     prog = 'git lab'


### PR DESCRIPTION
Fixes the issue #169 that I raised, and now both cases of "time.sleep(1)" (after failed contact with gitlab api) and other code should function correctly as far as I know.