### PR TITLE
Secret GitHub gists support

### DIFF
--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -719,7 +719,8 @@ class GitHub(GitSpindle):
            Show all gists for a user"""
         user = (opts['<user>'] or [self.gh.me().login])[0]
         for gist in self.gh.gists_by(user):
-            print("%s - %s" % (gist.html_url, gist.description))
+            secret = '(secret)' if not gist.public else ''
+            print("%s - %s %s" % (gist.html_url, gist.description, secret))
 
     @command
     def hooks(self, opts):

--- a/lib/gitspindle/github.py
+++ b/lib/gitspindle/github.py
@@ -698,7 +698,7 @@ class GitHub(GitSpindle):
 
     @command
     def gist(self, opts):
-        """[--description=<description>] <file>...
+        """[--secret] [--description=<description>] <file>...
            Create a new gist from files or stdin"""
         files = {}
         description = opts['--description'] or ''
@@ -710,7 +710,7 @@ class GitHub(GitSpindle):
                     err("No such file: %s" % f)
                 with open(f) as fd:
                     files[os.path.basename(f)] = {'content': fd.read()}
-        gist = self.gh.create_gist(description=description, files=files)
+        gist = self.gh.create_gist(description=description, files=files, public=not opts['--secret'])
         print("Gist created at %s" % gist.html_url)
 
     @command


### PR DESCRIPTION
Hi @seveas, this simple patch adds to things:

1. The possibility to create secret github gists adding the `--secret` flag.
    `echo test2 | git hub gist --secret test2 -`
2. A `(secret)` suffix to the gists listed with the `gists` command. e.g.
```
    https://gist.github.com/d4dfb2116eaf760019b0cdc621a82e2a - test2 (secret)
    https://gist.github.com/aa1d355c274aff23a7d113525b6d7b5d - test
```

I tried to add some tests but couldn't come up with something satisfactory (since the only way to check that a gist is secret is using the API). Maybe you have a suggestion on howto test this better.