### PR TITLE
Improve help option handling and version display

### DIFF
--- a/README
+++ b/README
@@ -39,225 +39,324 @@ Usage:
 
 Add an account to the configuration:
   git hub add-account [--host=<host>] <alias>
+
 Add a user as collaborator:
   git hub add-collaborator <user>...
+
 Add a deploy key:
   git hub add-deploy-key [--read-only] <key>...
+
 Add a repository hook:
   git hub add-hook <name> [<setting>...]
+
 Adds keys to your public keys:
   git hub add-public-keys [<key>...]
+
 Add user's fork as a named remote. The name defaults to the user's loginname:
   git hub add-remote [--ssh|--http|--git] <user> [<name>]
+
 Applies a pull request as a series of cherry-picks:
-  git hub apply-pr <pr-number>
+  git hub apply-pr [--ssh|--http|--git] <pr-number>
+
 Open the GitHub page for a repository in a browser:
   git hub browse [--parent] [<repo>] [<section>]
+
 Show a timeline of a user's activity:
   git hub calendar [<user>]
+
 Display the contents of a file on GitHub:
   git hub cat <file>...
+
 Check the github pages configuration and content of your repo:
   git hub check-pages [<repo>] [--parent]
+
 Clone a repository by name:
   git hub clone [--ssh|--http|--git] [--triangular [--upstream-branch=<branch>]] [--parent] [git-clone-options] <repo> [<dir>]
+
 List collaborators of a repository:
   git hub collaborators [<repo>]
+
 Configure git-spindle, similar to git-config:
   git hub config [--unset] <key> [<value>]
+
 Create a repository on github to push to:
   git hub create [--private] [--org=<org>] [--description=<description>]
-Create a personal access token that can be used for git operations:
-  git hub create-token [--store]
+
 Lists all keys for a repo:
   git hub deploy-keys [<repo>]
+
 Edit a hook:
   git hub edit-hook <name> [<setting>...]
+
 Fetch refs from a user's fork:
   git hub fetch [--ssh|--http|--git] <user> [<refspec>]
+
 Fork a repo and clone it:
   git hub fork [--ssh|--http|--git] [--triangular [--upstream-branch=<branch>]] [<repo>]
+
 List all forks of this repository:
   git hub forks [<repo>]
+
 Create a new gist from files or stdin:
   git hub gist [--description=<description>] <file>...
+
 Show all gists for a user:
   git hub gists [<user>]
+
 Show hooks that have been enabled:
   git hub hooks
+
 Show gitignore patterns for one or more languages:
   git hub ignore [<language>...]
+
 Show the IP addresses for github.com services in CIDR format:
   git hub ip-addresses [--git] [--hooks] [--importer] [--pages]
+
 Show issue details or report an issue:
   git hub issue [<repo>] [--parent] [<issue>...]
+
 List issues in a repository:
   git hub issues [<repo>] [--parent] [<filter>...]
+
 Display github log for yourself or other users. Or for an organisation or a repo:
   git hub log [--type=<type>] [--count=<count>] [--verbose] [<what>]
+
 Display the contents of a directory on GitHub:
   git hub ls [<dir>...]
+
 Mirror a repository, or all repositories for a user:
   git hub mirror [--ssh|--http|--git] [<repo>]
+
 Create a graphviz graph of followers and forks:
   git hub network [<level>]
+
 Protect a branch against deletions, force-pushes and failed status checks:
-  git hub protect [--enforcement-level=<level>] [--contexts=<contexts>] <branch>
+  git hub protect [--enforcement=<level>] [--status-checks=<contexts>] <branch>
+
 List active branch protections:
   git hub protected
+
 Lists all keys for a user:
   git hub public-keys [<user>]
+
 Opens a pull request to merge your branch to an upstream branch:
   git hub pull-request [--issue=<issue>] [--yes] [<yours:theirs>]
+
 Get the README for a repository:
   git hub readme [<repo>]
+
 Create a release:
   git hub release [--draft] [--prerelease] <tag> [<releasename>]
+
 List all releases:
   git hub releases [<repo>]
+
 Remove a user as collaborator:
   git hub remove-collaborator <user>...
+
 Remove deploy key by id:
   git hub remove-deploy-key <key>...
+
 Remove a hook:
   git hub remove-hook <name>
+
 Render a markdown document:
   git hub render [--save=<outfile>] <file>
+
 List all repos of a user, by default yours:
   git hub repos [--no-forks] [<user>]
+
 Let the octocat speak to you:
   git hub say [<msg>]
+
 Set the remote 'origin' to github.:
   git hub set-origin [--ssh|--http|--git] [--triangular [--upstream-branch=<branch>]]
+
 Display current and historical GitHub service status:
   git hub status
+
 Remove branch protections from a branch:
   git hub unprotect <branch>
+
 Display GitHub user info:
   git hub whoami
+
 Display GitHub user info:
   git hub whois <user>...
 
+
+
 Add an account to the configuration:
   git lab add-account [--host=<host>] <alias>
+
 Add a project member:
   git lab add-member [--access-level=guest|reporter|developer|master|owner] <user>...
+
 Adds keys to your public keys:
   git lab add-public-keys [<key>...]
+
 Add user's fork as a named remote. The name defaults to the user's loginname:
   git lab add-remote [--ssh|--http] <user> [<name>]
+
 Applies a merge request as a series of cherry-picks:
-  git lab apply-merge <merge-request-number>
+  git lab apply-merge [--ssh|--http] <merge-request-number>
+
 Open the GitLab page for a repository in a browser:
   git lab browse [--parent] [<repo>] [<section>]
+
 Show a timeline of a user's activity:
   git lab calendar [<user>]
+
 Display the contents of a file on GitLab:
   git lab cat <file>...
+
 Clone a repository by name:
   git lab clone [--ssh|--http] [--triangular [--upstream-branch=<branch>]] [--parent] [git-clone-options] <repo> [<dir>]
+
 Configure git-spindle, similar to git-config:
   git lab config [--unset] <key> [<value>]
+
 Create a repository on gitlab to push to:
   git lab create [--private|--internal] [--group=<group>] [--description=<description>]
+
 Fetch refs from a user's fork:
   git lab fetch [--ssh|--http] <user> [<refspec>]
+
 Fork a repo and clone it:
   git lab fork [--ssh|--http] [--triangular [--upstream-branch=<branch>]] [<repo>]
+
 Show issue details or report an issue:
   git lab issue [<repo>] [--parent] [<issue>...]
+
 List issues in a repository:
   git lab issues [<repo>] [--parent] [<filter>...]
+
 Display GitLab log for a repository:
   git lab log [<repo>]
+
 Display the contents of a directory on GitLab:
   git lab ls [<dir>...]
+
 List repo memberships:
   git lab members [<repo>]
+
 Opens a merge request to merge your branch to an upstream branch:
   git lab merge-request [--yes] [<yours:theirs>]
+
 Mirror a repository, or all your repositories:
   git lab mirror [--ssh|--http] [<repo>]
+
 Protect a branch against force-pushes:
   git lab protect <branch>
+
 List protected branches:
   git lab protected
+
 Lists all keys for a user:
   git lab public-keys [<user>]
+
 Remove a user's membership:
   git lab remove-member <user>...
+
 List all your repos:
   git lab repos [--no-forks]
+
 Set the remote 'origin' to gitlab.:
   git lab set-origin [--ssh|--http] [--triangular [--upstream-branch=<branch>]]
+
 Remove force-push protection from a branch:
   git lab unprotect <branch>
+
 Display GitLab user info:
   git lab whoami
+
 Display GitLab user info:
   git lab whois <user>...
 
+
+
 Add an account to the configuration:
   git bb add-account <alias>
+
 Add a deploy key:
   git bb add-deploy-key <key>...
-Add privileges for a user to this repo:
-  git bb add-privilege [--admin|--read|--write] <user>...
+
 Adds keys to your public keys:
   git bb add-public-keys [<key>...]
+
 Add user's fork as a named remote. The name defaults to the user's loginname:
   git bb add-remote [--ssh|--http] <user> [<name>]
+
 Applies a pull request as a series of cherry-picks:
-  git bb apply-pr <pr-number>
-Open the GitHub page for a repository in a browser:
+  git bb apply-pr [--ssh|--http] <pr-number>
+
+Open the Bitbucket page for a repository in a browser:
   git bb browse [--parent] [<repo>] [<section>]
+
 Display the contents of a file on BitBucket:
   git bb cat <file>...
+
 Clone a repository by name:
   git bb clone [--ssh|--http] [--triangular [--upstream-branch=<branch>]] [--parent] [git-clone-options] <repo> [<dir>]
+
 Configure git-spindle, similar to git-config:
   git bb config [--unset] <key> [<value>]
+
 Create a repository on bitbucket to push to:
   git bb create [--private] [--team=<team>] [--description=<description>]
+
 Lists all keys for a repo:
   git bb deploy-keys [<repo>]
+
 Fetch refs from a user's fork:
   git bb fetch [--ssh|--http] <user> [<refspec>]
+
 Fork a repo and clone it:
   git bb fork [--ssh|--http] [--triangular [--upstream-branch=<branch>]] [<repo>]
+
 List all forks of this repository:
   git bb forks [<repo>]
-Invite users to collaborate on this repository:
-  git bb invite [--read|--write|--admin] <email>...
+
 Show issue details or report an issue:
   git bb issue [<repo>] [--parent] [<issue>...]
+
 List issues in a repository:
   git bb issues [<repo>] [--parent] [<filter>...]
+
 Display the contents of a directory on BitBucket:
   git bb ls [<dir>...]
+
 Mirror a repository, or all repositories for a user:
   git bb mirror [--ssh|--http] [<repo>]
-List repo privileges:
-  git bb privileges [<repo>]
+
+List repo permissions:
+  git bb permissions [<repo>]
+
 Lists all keys for a user:
   git bb public-keys [<user>]
+
 Opens a pull request to merge your branch to an upstream branch:
   git bb pull-request [--yes] [<yours:theirs>]
+
 Remove deploy key by id:
   git bb remove-deploy-key <key>...
-Remove a user's privileges:
-  git bb remove-privilege <user>...
-List all repos of a user, by default yours:
-  git bb repos [--no-forks] [<user>]
-Set the remote 'origin' to github.:
+
+List all repos of a workspace, or your repos:
+  git bb repos [--no-forks] [<workspace>]
+
+Set the remote 'origin' to bitbucket.:
   git bb set-origin [--ssh|--http] [--triangular [--upstream-branch=<branch>]]
+
 Create a new snippet from files or stdin:
   git bb snippet [--description=<description>] <file>...
+
 Show all snippets for a user:
   git bb snippets [<user>]
+
 Display BitBucket user info:
   git bb whoami
-Display GitHub user info:
+
+Display Bitbucket user info:
   git bb whois <user>...
 
 Copyright (C) 2012-2020 Dennis Kaarsemaker <dennis@kaarsemaker.net>

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -32,7 +32,7 @@ If you want to see this information about other users, use :command:`git bb whoi
   [1;4mBill Blough[0m
   Profile:  https://bitbucket.org/bblough
 
-.. describe:: git bb repos [--no-forks] [<user>]
+.. describe:: git bb repos [--no-forks] [<workspace>]
 
 List all repositories owned by a user, by default you. Specify :option:`--no-forks`
 to exclude forked repositories.
@@ -164,24 +164,12 @@ argument, the current repository will be updated. You can also specify
 
 Administering repositories
 --------------------------
-.. describe:: git bb privileges [<repo>]
+.. describe:: git bb permissions [<repo>]
 
 List all people with access to this repository. Beware that BitBucket
 aggressively caches permissions and it can take up to a minute for a change in
 permissions to be reflected in the output of this command. The owner of the
 repository is also not listed in the output.
-
-.. describe:: git bb add-privilege [--admin|--read|--write] <user>...
-
-Grant people read, write or admin access to this repository.
-
-.. describe:: git bb remove-privilege <user>...
-
-Revoke access to this repository.
-
-.. describe:: git bb invite [--read|--write|--admin] <email>...
-
-Invite users by e-mail to collaborate on this repository.
 
 .. describe:: git bb deploy-keys [<repo>]
 
@@ -205,7 +193,7 @@ Issues and pull requests
 List all open issues for the current repository, or the one specified in the
 `<repo>` argument. If you run this outside a repository, or with `--` as
 `<repo>`, it will list issues in all your repositories.  When you
-specify :option:`--parent`, this will operate on the parent repositoryD.
+specify :option:`--parent`, this will operate on the parent repository.
 
 You can specify filters in the form `filter=value` to filter issues. Supported
 filters are:
@@ -236,11 +224,15 @@ message contain the shortlog and diffstat of the commits that you're asking to
 be merged. Note that if you use any characterset in your logs and filenames
 that is not ascii or utf-8, git bb will misbehave.
 
-.. describe:: git bb apply-pr <pr-number>
+.. describe:: git bb apply-pr [--ssh|--http] <pr-number>
 
 BitBucket makes it easy for you to merge pull requests, but if you want to keep
 your history linear, this one is for you. It applies a pull request using
 :command:`git cherry-pick` instead of merging.
+
+For own and private repos, by default an SSH url is used to fetch the changes.
+For foreign public repos, by default an HTTP url is used.
+This can be overridden using the command options.
 
 Snippets
 --------

--- a/docs/github.rst
+++ b/docs/github.rst
@@ -85,17 +85,6 @@ e.g. :option:`--type=push`. You can also get more (or less) than the default 30
 items in the log by specifying a count. Finally, :option:`--verbose` will give
 slightly more verbose output for some log items.
 
-.. describe:: git hub create-token [--store]
-
-Create a personal access token that can be used for git operations (clone,
-fetch, push) over http. Especially useful if you use two-factor authentication,
-as these tokens can be used instead of your password and don't require the
-second factor.
-
-The token is shown in the output of the command. If you specify
-:option:`--store`, the token will also be stored using the git credential
-helpers.
-
 .. _`profile page`: https://github.com/settings/applications
 
 Using multiple accounts
@@ -262,7 +251,7 @@ Revoke access to this repository.
 List all protected branches. Protected branches cannot be force-pushed or
 deleted, and can potentially have required status checks.
 
-.. describe:: git hub protect [--enforcement=<level>] [--status_checks=<contexts>] <branch>
+.. describe:: git hub protect [--enforcement=<level>] [--status-checks=<contexts>] <branch>
 
 Protect a branch against force-pushes and deletion. Optionally require status
 checks to succeed by specifying their context (e.g.
@@ -316,7 +305,7 @@ Issues and pull requests
 List all open issues for the current repository, or the one specified in the
 `<repo>` argument. If you run this outside a repository, or with `--` as
 `<repo>`, it will list issues in all your repositories.  When you
-specify :option:`--parent`, this will operate on the parent repositoryD.
+specify :option:`--parent`, this will operate on the parent repository.
 
 You can specify filters in the form `filter=value` to filter issues. Supported
 filters are:
@@ -350,11 +339,15 @@ that is not ascii or utf-8, git hub will misbehave.
 If you specify an issue number, that issue will be turned into a pull request
 and you will not be asked to write a pull request message.
 
-.. describe:: git hub apply-pr <pr-number>
+.. describe:: git hub apply-pr [--ssh|--http|--git] <pr-number>
 
 GitHub makes it easy for you to merge pull requests, but if you want to keep
 your history linear, this one is for you. It applies a pull request using
 :command:`git cherry-pick` instead of merging.
+
+For own and private repos, by default an SSH url is used to fetch the changes.
+For foreign public repos, by default an HTTP url is used.
+This can be overridden using the command options.
 
 .. _`filters`: http://github3py.readthedocs.org/en/latest/repos.html#github3.repos.Repository.list_issues
 

--- a/docs/gitlab.rst
+++ b/docs/gitlab.rst
@@ -222,7 +222,7 @@ Issues and pull requests
 List all open issues for the current repository, or the one specified in the
 `<repo>` argument. If you run this outside a repository, or with `--` as
 `<repo>`, it will list issues in all your repositories.  When you
-specify :option:`--parent`, this will operate on the parent repositoryD.
+specify :option:`--parent`, this will operate on the parent repository.
 
 You can specify filters in the form `filter=value` to filter issues. Supported
 filters are:
@@ -254,11 +254,15 @@ that is not ascii or utf-8, git lab will misbehave.
 If you specify an issue number, that issue will be turned into a pull request
 and you will not be asked to write a pull request message.
 
-.. describe:: git lab apply-merge <merge-request-number>
+.. describe:: git lab apply-merge [--ssh|--http] <merge-request-number>
 
 GitLab makes it easy for you to merge merge requests, but if you want to keep
 your history linear, this one is for you. It applies a merge request using
 :command:`git cherry-pick` instead of merging.
+
+For own and private repos, by default an SSH url is used to fetch the changes.
+For foreign public repos, by default an HTTP url is used.
+This can be overridden using the command options.
 
 .. _`filters`: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/issues.md
 

--- a/test/901_docs.t
+++ b/test/901_docs.t
@@ -5,13 +5,26 @@ test_description="Testing docstring propagation"
 . ./setup.sh
 
 test_expect_success author "Is README up-to-date" "
-    git_hub_1 -h > expected.tmp &&
-    git_lab_1 -h >> expected.tmp &&
-    git_bb_1 -h >> expected.tmp &&
-    grep -A1 '^  git \\(hub\\|lab\\|bb\\) ' expected.tmp | sed -s 's/ \\[options\\]//' > expected &&
-    grep -A1 '^  git \\(hub\\|lab\\|bb\\) ' '$SHARNESS_BUILD_DIRECTORY/README' > actual &&
+    for command in \$(git_hub -h | awk '
+        /Options:/ { command = 0 }
+        command { print \$1 }
+        /Commands:/ { command = 1 }
+    '); do git_hub -h \$command; echo; done > expected.tmp &&
+    for command in \$(git_lab -h | awk '
+        /Options:/ { command = 0 }
+        command { print \$1 }
+        /Commands:/ { command = 1 }
+    '); do git_lab -h \$command; echo; done >> expected.tmp &&
+    for command in \$(git_bb -h | awk '
+        /Options:/ { command = 0 }
+        command { print \$1 }
+        /Commands:/ { command = 1 }
+    '); do git_bb -h \$command; echo; done >> expected.tmp &&
+    sed 's/ \\[options\\]//' expected.tmp > expected &&
+    grep -C1 '^  git \\(hub\\|lab\\|bb\\) ' '$SHARNESS_BUILD_DIRECTORY/README' | grep -v '^--$' > actual &&
     test_cmp expected actual
 "
+
 test_expect_success author "Are usage strings in docs/ up-to-date" "
     grep '^  git \\(hub\\|lab\\|bb\\) ' expected.tmp | sed -s 's/ \\[options\\]//' > expected &&
     sed -ne 's/^\\.\\. describe::/ /p' '$SHARNESS_BUILD_DIRECTORY/docs/github.rst' | sort > actual &&


### PR DESCRIPTION
- Update commands and options in README and reST docs
- Add blank lines between commands in README for improved readability
- Do not raise an exception when requesting help for a non-existing
  command
- Exit with return code 0 if help was explicitly requested
- Add capability to show version with --version option
- Adapt 901 docs tests to the new pretty help format